### PR TITLE
Use passive event listener for touchmove (to prevent scrolling while swiping)

### DIFF
--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -127,6 +127,11 @@ export class InnerSlider extends React.Component {
       this.callbackTimers.forEach(timer => clearTimeout(timer));
       this.callbackTimers = [];
     }
+    if(this.props.touchMove) {
+      this.list.removeEventListener("touchmove", this.swipeMove, {
+        passive: false
+      });
+    }
     if (window.addEventListener) {
       window.removeEventListener("resize", this.onWindowResized);
     } else {

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -99,7 +99,11 @@ export class InnerSlider extends React.Component {
     );
 
     if (this.props.touchMove) {
-      this.list.addEventListener("touchmove", this.swipeMove);
+      // swipeMove calls preventDefault which only has an effect on non-passive events
+      // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+      this.list.addEventListener("touchmove", this.swipeMove, {
+        passive: false
+      });
     }
 
     // To support server-side rendering
@@ -196,7 +200,11 @@ export class InnerSlider extends React.Component {
 
     if (prevProps.touchMove !== this.props.touchMove) {
       const method = this.props.touchMove ? "add" : "remove";
-      this.list[`${method}EventListener`]("touchmove", this.swipeMove);
+      // swipeMove calls preventDefault which only has an effect on non-passive events
+      // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
+      this.list[`${method}EventListener`]("touchmove", this.swipeMove, {
+        passive: false
+      });
     }
   };
   onWindowResized = setTrackStyle => {
@@ -286,15 +294,15 @@ export class InnerSlider extends React.Component {
     let childrenCount = React.Children.count(this.props.children);
     const spec = { ...this.props, ...this.state, slideCount: childrenCount };
     let slideCount = getPreClones(spec) + getPostClones(spec) + childrenCount;
-    let trackWidth = 100 / this.props.slidesToShow * slideCount;
+    let trackWidth = (100 / this.props.slidesToShow) * slideCount;
     let slideWidth = 100 / slideCount;
     let trackLeft =
-      -slideWidth *
-      (getPreClones(spec) + this.state.currentSlide) *
-      trackWidth /
+      (-slideWidth *
+        (getPreClones(spec) + this.state.currentSlide) *
+        trackWidth) /
       100;
     if (this.props.centerMode) {
-      trackLeft += (100 - slideWidth * trackWidth / 100) / 2;
+      trackLeft += (100 - (slideWidth * trackWidth) / 100) / 2;
     }
     let trackStyle = {
       width: trackWidth + "%",

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -97,6 +97,11 @@ export class InnerSlider extends React.Component {
         slide.onblur = this.props.pauseOnFocus ? this.onSlideBlur : null;
       }
     );
+
+    if (this.props.touchMove) {
+      this.list.addEventListener("touchmove", this.swipeMove);
+    }
+
     // To support server-side rendering
     if (!window) {
       return;
@@ -167,7 +172,7 @@ export class InnerSlider extends React.Component {
       }
     });
   };
-  componentDidUpdate = () => {
+  componentDidUpdate = prevProps => {
     this.checkImagesLoad();
     this.props.onReInit && this.props.onReInit();
     if (this.props.lazyLoad) {
@@ -188,6 +193,11 @@ export class InnerSlider extends React.Component {
     //   this.props.onLazyLoad([leftMostSlide])
     // }
     this.adaptHeight();
+
+    if (prevProps.touchMove !== this.props.touchMove) {
+      const method = this.props.touchMove ? "add" : "remove";
+      this.list[`${method}EventListener`]("touchmove", this.swipeMove);
+    }
   };
   onWindowResized = setTrackStyle => {
     if (this.debouncedResize) this.debouncedResize.cancel();
@@ -704,7 +714,6 @@ export class InnerSlider extends React.Component {
       onMouseUp: touchMove ? this.swipeEnd : null,
       onMouseLeave: this.state.dragging && touchMove ? this.swipeEnd : null,
       onTouchStart: touchMove ? this.swipeStart : null,
-      onTouchMove: this.state.dragging && touchMove ? this.swipeMove : null,
       onTouchEnd: touchMove ? this.swipeEnd : null,
       onTouchCancel: this.state.dragging && touchMove ? this.swipeEnd : null,
       onKeyDown: this.props.accessibility ? this.keyHandler : null

--- a/src/utils/innerSliderUtils.js
+++ b/src/utils/innerSliderUtils.js
@@ -331,6 +331,7 @@ export const swipeMove = (e, spec) => {
   const {
     scrolling,
     animating,
+    dragging,
     vertical,
     swipeToSlide,
     verticalSwiping,
@@ -349,7 +350,7 @@ export const swipeMove = (e, spec) => {
     listHeight,
     listWidth
   } = spec;
-  if (scrolling) return;
+  if (scrolling || !dragging) return;
   if (animating) return e.preventDefault();
   if (vertical && swipeToSlide && verticalSwiping) e.preventDefault();
   let swipeLeft,


### PR DESCRIPTION
This small patch restores react-slider's ability to disable vertical scrolling when swiping through a slider on iOS.

Seems the `touchmove` event listener that React adds (when using the React's event system via event props) is not configured as a non-passive listener. iOS ([starting with iOS 11.3](https://stackoverflow.com/a/49582193)) has made all _root document_ touch event listeners passive by default to improve scrolling performance. React's event system attaches event handlers to the document root, which will result in a passive `touchmove` listener on iOS, which in turn means that `preventDefault()` has no effect.

The proposed solution in https://github.com/facebook/react/issues/2043 should fix the issue, but for now adding the event listener directly to the node also solves the problem.

Please note, the `{passive: false}` in the addEventListener call in this PR is not technically necessary as only _document root_ event listeners are passive by default on iOS, but it does explicitly communicate the intent.