### PR TITLE
Fix swipe-tap issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased](https://github.com/DomainGroupOSS/react-slick/tree/HEAD)
+### Fixed
+- Fix issue preventing the first tap after a swipe from being propagated
 
 ## [0.24.3][] - 2019-06-03
 

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -418,6 +418,7 @@ export class InnerSlider extends React.Component {
         asNavFor.innerSlider.slideHandler(index);
       if (!nextState) return;
       this.animationEndCallback = setTimeout(() => {
+        this.clickable = true;
         const { animating, ...firstBatch } = nextState;
         this.setState(firstBatch, () => {
           this.callbackTimers.push(


### PR DESCRIPTION
`clickable` flag was set to false after a swipe, but not reset once the animation had completed.