### PR TITLE
Moved restoration of clickable flag from animation timer into a separ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## [Unreleased](https://github.com/DomainGroupOSS/react-slick/tree/HEAD)
 
+- Fixed
+
+  - Moved restoration of clickable flag from animation cooldown timer into another separate timer (AH-4429)
+
 ## [0.24.4][] - 2019-06-05
+
 ### Fixed
+
 - Fix issue preventing the first tap after a swipe from being propagated
 
 ## [0.24.3][] - 2019-06-03
@@ -163,7 +169,5 @@ Following are the changes to be mentioned:
 [0.24.2]: https://github.com/DomainGroupOSS/react-slick/tree/v0.24.2
 [unreleased]: https://github.com/DomainGroupOSS/react-slick/compare/v0.24.3...HEAD
 [0.24.3]: https://github.com/DomainGroupOSS/react-slick/tree/v0.24.3
-
-
-[Unreleased]: https://github.com/DomainGroupOSS/react-slick/compare/v0.24.4...HEAD
+[unreleased]: https://github.com/DomainGroupOSS/react-slick/compare/v0.24.4...HEAD
 [0.24.4]: https://github.com/DomainGroupOSS/react-slick/tree/v0.24.4

--- a/src/inner-slider.js
+++ b/src/inner-slider.js
@@ -127,7 +127,10 @@ export class InnerSlider extends React.Component {
       this.callbackTimers.forEach(timer => clearTimeout(timer));
       this.callbackTimers = [];
     }
-    if(this.props.touchMove) {
+    if (this.unblockClickableTimer) {
+      clearTimeout(this.unblockClickableTimer);
+    }
+    if (this.props.touchMove) {
       this.list.removeEventListener("touchmove", this.swipeMove, {
         passive: false
       });
@@ -287,9 +290,7 @@ export class InnerSlider extends React.Component {
       };
       if (this.props.centerMode) {
         let currentWidth = `${childrenWidths[this.state.currentSlide]}px`;
-        trackStyle.left = `calc(${
-          trackStyle.left
-        } + (100% - ${currentWidth}) / 2 ) `;
+        trackStyle.left = `calc(${trackStyle.left} + (100% - ${currentWidth}) / 2 ) `;
       }
       this.setState({
         trackStyle
@@ -498,6 +499,9 @@ export class InnerSlider extends React.Component {
     let triggerSlideHandler = state["triggerSlideHandler"];
     delete state["triggerSlideHandler"];
     this.setState(state);
+    this.unblockClickableTimer = setTimeout(() => {
+      this.clickable = true;
+    }, this.props.speed);
     if (triggerSlideHandler === undefined) return;
     this.slideHandler(triggerSlideHandler);
     if (this.props.verticalSwiping) {


### PR DESCRIPTION
Moved restoration of clickable flag from animation timer into a separate timer.

This fixes the issue where swiping the carousel, but not moving all the way to a new slide, blocks the next click event.