### PR TITLE
fix: fix SSR and responsive mode hydration issue

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -6,7 +6,7 @@ import Slider from "../src/index";
 
 describe("Slider", function() {
   it("should render", function() {
-    const wrapper = shallow(
+    const wrapper = mount(
       <Slider>
         <div>slide1</div>
       </Slider>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@domain-group/react-slick",
-  "version": "0.24.5-gamma.1",
+  "version": "0.24.5-gamma.6",
   "description": "React port of slick carousel",
   "main": "./lib",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@domain-group/react-slick",
-  "version": "0.24.5",
-  "description": " React port of slick carousel",
+  "version": "0.24.5-gamma.1",
+  "description": "React port of slick carousel",
   "main": "./lib",
   "files": [
     "dist",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-import Slider from "./slider";
+import Slider from "./slider-ssr";
 
 export default Slider;

--- a/src/slider-ssr.js
+++ b/src/slider-ssr.js
@@ -1,7 +1,7 @@
-import React, { Component } from "react";
+import React, { Component, forwardRef } from "react";
 import SlickSlider from "./slider";
 
-class Slider extends Component {
+class SliderInner extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -21,6 +21,7 @@ class Slider extends Component {
       <SlickSlider
         key={isClient ? "client" : "server"}
         responsive={isClient ? responsive : null}
+        ref={this.props.innerRef}
         {...rest}
       >
         {children}
@@ -28,5 +29,9 @@ class Slider extends Component {
     );
   }
 }
+
+const Slider = forwardRef((props, ref) => (
+  <SliderInner {...props} innerRef={ref} />
+));
 
 export default Slider;

--- a/src/slider-ssr.js
+++ b/src/slider-ssr.js
@@ -1,0 +1,32 @@
+import React, { Component } from "react";
+import SlickSlider from "./slider";
+
+class Slider extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isClient: false
+    };
+  }
+
+  componentDidMount() {
+    this.setState({ isClient: true });
+  }
+
+  render() {
+    const { children, responsive, ...rest } = this.props;
+    const { isClient } = this.state;
+
+    return (
+      <SlickSlider
+        key={isClient ? "client" : "server"}
+        responsive={isClient ? responsive : null}
+        {...rest}
+      >
+        {children}
+      </SlickSlider>
+    );
+  }
+}
+
+export default Slider;


### PR DESCRIPTION
fix SSR and responsive mode hydration issue

Issue:

- On the server, elements are rendered based on initial conditions.
- On the client, a second render adds elements based on responsiveness, leading to mismatches.

Fix:

- Set responsive to null during server-side rendering to prevent mismatched elements.
- Ensure a re-render on the client by changing the key.


https://github.com/akiran/react-slick/issues/1245#issuecomment-463250189